### PR TITLE
Use canonical state keys during training episodes

### DIFF
--- a/ultimate_ttt/train.py
+++ b/ultimate_ttt/train.py
@@ -16,7 +16,7 @@ def play_episode(agent: UltimateTTTRLAI, epsilon: float) -> Tuple[str, int]:
     move_count = 0
 
     while not game.terminal:
-        state_key = game.serialize(current_player)
+        state_key = agent._state_key(game, current_player)
         moves = game.available_moves()
         move = agent.choose_action(state_key, moves, epsilon)
         game.make_move(current_player, move)
@@ -37,7 +37,7 @@ def play_episode(agent: UltimateTTTRLAI, epsilon: float) -> Tuple[str, int]:
             )
 
         next_player = "O" if current_player == "X" else "X"
-        next_state_key = game.serialize(next_player)
+        next_state_key = agent._state_key(game, next_player)
         next_moves = game.available_moves()
         agent.update(state_key, move, 0.0, next_state_key, next_moves)
         current_player = next_player


### PR DESCRIPTION
## Summary
- switch the training loop to use the agent's canonical state keys for both the current and next turns
- ensure Q-value updates during self-play are applied to the canonical entries directly

## Testing
- python -m ultimate_ttt.train --episodes 5 --model-path ultimate_ttt/models/test_q.json --epsilon-start 0.2 --epsilon-end 0.1 --seed 42
- python - <<'PY'
import json
from pathlib import Path
path = Path('ultimate_ttt/models/test_q.json')
with path.open() as fh:
    data = json.load(fh)
nonzero = []
for state, moves in data['q_values'].items():
    for move, value in moves.items():
        if abs(value) > 1e-9:
            nonzero.append((state, move, value))
            if len(nonzero) >= 5:
                break
    if len(nonzero) >= 5:
        break
print('found', len(nonzero), 'non-zero entries')
for entry in nonzero:
    print(entry[0][:30] + '...', entry[1], entry[2])
PY

------
https://chatgpt.com/codex/tasks/task_e_68d6e9f9dca8832384b4f06f0970faa8