### PR TITLE
Implement AlphaZero training pipeline for Ultimate TTT

### DIFF
--- a/ultimate_ttt/__init__.py
+++ b/ultimate_ttt/__init__.py
@@ -1,13 +1,22 @@
-"""Ultimate Tic-Tac-Toe game package with GUI and reinforcement learning agent."""
+"""Ultimate Tic-Tac-Toe game package with GUI and learning utilities."""
 from .ai import UltimateTTTRLAI
+from .arena import Arena, ArenaResult
 from .game import InvalidMoveError, Move, UltimateTicTacToe
 from .gui import UltimateTTTApp, main
+from .model import PolicyValueNet
+from .mcts import MCTS
+from .train_az import train
 
 __all__ = [
     "UltimateTTTRLAI",
+    "Arena",
+    "ArenaResult",
     "InvalidMoveError",
     "Move",
     "UltimateTicTacToe",
     "UltimateTTTApp",
+    "PolicyValueNet",
+    "MCTS",
+    "train",
     "main",
 ]

--- a/ultimate_ttt/arena.py
+++ b/ultimate_ttt/arena.py
@@ -1,0 +1,87 @@
+"""Evaluation arena comparing two agents via self-play matches."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+
+from .game import UltimateTicTacToe, index_to_action
+from .mcts import MCTS
+from .model import PolicyValueNet
+
+__all__ = ["Arena", "ArenaResult"]
+
+
+@dataclass
+class ArenaResult:
+    wins: int
+    losses: int
+    draws: int
+
+    @property
+    def total(self) -> int:
+        return self.wins + self.losses + self.draws
+
+    @property
+    def win_rate(self) -> float:
+        return self.wins / self.total if self.total else 0.0
+
+
+@dataclass
+class Arena:
+    challenger: PolicyValueNet
+    baseline: PolicyValueNet
+    mcts_simulations: int = 200
+    c_puct: float = 2.0
+    rng: Optional[np.random.Generator] = None
+
+    def _create_mcts(self, model: PolicyValueNet) -> MCTS:
+        return MCTS(
+            model=model,
+            num_simulations=self.mcts_simulations,
+            c_puct=self.c_puct,
+            dirichlet_epsilon=0.0,
+            dirichlet_alpha=0.3,
+            rng=self.rng,
+        )
+
+    def play_matches(self, num_games: int = 200) -> ArenaResult:
+        results = ArenaResult(wins=0, losses=0, draws=0)
+
+        for game_index in range(num_games):
+            game = UltimateTicTacToe()
+            challenger_first = (game_index % 2 == 0)
+            players = {
+                "X": self.challenger if challenger_first else self.baseline,
+                "O": self.baseline if challenger_first else self.challenger,
+            }
+            mcts_cache = {role: self._create_mcts(model) for role, model in players.items()}
+
+            while not game.terminal:
+                player_to_move = game.active_player()
+                mcts = mcts_cache[player_to_move]
+                _, root = mcts.run(game, add_noise=False)
+                visit_counts = root.visit_counts.astype(np.float32)
+                legal = game.legal_action_mask()
+                legal_indices = np.flatnonzero(legal)
+                if legal_indices.size == 0:
+                    break
+                best_action = int(legal_indices[int(np.argmax(visit_counts[legal_indices]))])
+                game.make_move(player_to_move, index_to_action(best_action))
+
+            outcome = game.terminal_outcome_from_x_perspective()
+            if outcome > 0:
+                if challenger_first:
+                    results.wins += 1
+                else:
+                    results.losses += 1
+            elif outcome < 0:
+                if challenger_first:
+                    results.losses += 1
+                else:
+                    results.wins += 1
+            else:
+                results.draws += 1
+
+        return results

--- a/ultimate_ttt/config.yaml
+++ b/ultimate_ttt/config.yaml
@@ -1,0 +1,28 @@
+training:
+  seed: 0
+  use_gpu: true
+  channels: 64
+  res_blocks: 8
+  learning_rate: 0.0003
+  weight_decay: 0.0001
+  batch_size: 256
+  steps_per_cycle: 1000
+  cycles: 10
+  grad_clip: 1.0
+  checkpoint: ultimate_ttt/models/az_checkpoint.pt
+selfplay:
+  games_per_cycle: 50
+  simulations: 400
+  c_puct: 2.0
+  dirichlet_epsilon: 0.25
+  dirichlet_alpha: 0.3
+  temperature_moves: 16
+  augment: true
+replay:
+  capacity: 200000
+evaluation:
+  interval: 5
+  matches: 200
+  simulations: 200
+  c_puct: 2.0
+  threshold: 0.55

--- a/ultimate_ttt/features.py
+++ b/ultimate_ttt/features.py
@@ -1,0 +1,77 @@
+"""Feature construction utilities for the AlphaZero-style agent."""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .game import UltimateTicTacToe
+
+__all__ = ["encode_state", "FEATURE_CHANNELS"]
+
+FEATURE_CHANNELS = 8
+
+
+def _global_coords(sub_index: int, cell_index: int) -> Tuple[int, int]:
+    macro_row, macro_col = divmod(sub_index, 3)
+    cell_row, cell_col = divmod(cell_index, 3)
+    return macro_row * 3 + cell_row, macro_col * 3 + cell_col
+
+
+def _mark_sub_board(mask: np.ndarray, sub_index: int, value: float) -> None:
+    row_offset = (sub_index // 3) * 3
+    col_offset = (sub_index % 3) * 3
+    mask[row_offset : row_offset + 3, col_offset : col_offset + 3] = value
+
+
+def encode_state(game: UltimateTicTacToe) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (planes, legal_mask) for the provided game state."""
+
+    planes = np.zeros((FEATURE_CHANNELS, 9, 9), dtype=np.float32)
+    legal_mask = game.legal_action_mask()
+
+    # Stones for X and O
+    for sub_index, board in enumerate(game.boards):
+        for cell_index, value in enumerate(board):
+            if value == " ":
+                continue
+            row, col = _global_coords(sub_index, cell_index)
+            if value == "X":
+                planes[0, row, col] = 1.0
+            elif value == "O":
+                planes[1, row, col] = 1.0
+
+    # Player to move (single plane; 1 if X to move, else 0)
+    to_move = game.active_player()
+    if to_move == "X":
+        planes[2, :, :] = 1.0
+
+    # Legal moves mask (per-cell)
+    for action_index, allowed in enumerate(legal_mask):
+        if allowed:
+            sub_index, cell_index = divmod(action_index, 9)
+            row, col = _global_coords(sub_index, cell_index)
+            planes[3, row, col] = 1.0
+
+    # Forced sub-board mask
+    forced = game.forced_board_index()
+    if forced is not None:
+        _mark_sub_board(planes[4], forced, 1.0)
+    else:
+        for sub_index, macro_status in enumerate(game.macro_board):
+            if macro_status == " ":
+                _mark_sub_board(planes[4], sub_index, 1.0)
+
+    # Macro board wins (upsampled to 9x9)
+    for sub_index, macro_status in enumerate(game.macro_board):
+        if macro_status == "X":
+            _mark_sub_board(planes[5], sub_index, 1.0)
+        elif macro_status == "O":
+            _mark_sub_board(planes[6], sub_index, 1.0)
+
+    # Last move one-hot
+    if game.last_move is not None:
+        row, col = _global_coords(*game.last_move)
+        planes[7, row, col] = 1.0
+
+    return planes, legal_mask.astype(bool)

--- a/ultimate_ttt/game.py
+++ b/ultimate_ttt/game.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Sequence, Tuple
 
+import numpy as np
+
+from .symmetry import MACRO_MAPPINGS
+
 Player = str  # Either "X" or "O"
 Move = Tuple[int, int]
 
@@ -25,8 +29,6 @@ WIN_LINES: Tuple[Tuple[int, int, int], ...] = (
     (0, 4, 8),
     (2, 4, 6),
 )
-
-
 class InvalidMoveError(RuntimeError):
     """Raised when a move is attempted that is not legal in the current state."""
 
@@ -83,6 +85,11 @@ class UltimateTicTacToe:
                     moves.append((sub_idx, cell_idx))
         return moves
 
+    def forced_board_index(self) -> Optional[int]:
+        """Public accessor exposing the index of the forced sub-board, if any."""
+
+        return self._forced_board_index()
+
     def _forced_board_index(self) -> Optional[int]:
         if self.last_move is None:
             return None
@@ -115,6 +122,25 @@ class UltimateTicTacToe:
 
         self._update_macro_board()
 
+    def legal_action_mask(self) -> np.ndarray:
+        """Return a boolean mask over the 81 global actions that are legal."""
+
+        mask = np.zeros(81, dtype=bool)
+        for sub_idx, cell_idx in self.available_moves():
+            mask[sub_idx * 9 + cell_idx] = True
+        return mask
+
+    def terminal_outcome_from_x_perspective(self) -> float:
+        """Return +1/-1/0 from X's perspective for terminal positions."""
+
+        if not self.terminal:
+            raise ValueError("terminal_outcome_from_x_perspective called before game end")
+        if self.winner == "X":
+            return 1.0
+        if self.winner == "O":
+            return -1.0
+        return 0.0
+
     def _update_sub_board(self, board_index: int) -> str:
         board = self.boards[board_index]
         for line in WIN_LINES:
@@ -146,6 +172,13 @@ class UltimateTicTacToe:
         forced = self._forced_board_index()
         forced_repr = "*" if forced is None else str(forced)
         return f"{current_player}:{boards_repr}#{macro_repr}#{forced_repr}"
+
+    def serialize_canonical(self, current_player: Player) -> str:
+        forced = self._forced_board_index()
+        canonical, _ = canonicalize_state(
+            current_player, self.boards, self.macro_board, forced
+        )
+        return canonical
 
     def render_ascii(self) -> str:
         def cell_value(board: Sequence[str], idx: int) -> str:
@@ -189,4 +222,60 @@ class UltimateTicTacToe:
 
 
 def moves_to_indices(moves: Iterable[Move]) -> Sequence[int]:
-    return tuple(sub * 9 + cell for sub, cell in moves)
+    return tuple(action_to_index(move) for move in moves)
+
+
+def action_to_index(move: Move) -> int:
+    sub_idx, cell_idx = move
+    if not 0 <= sub_idx < 9 or not 0 <= cell_idx < 9:
+        raise ValueError("move components must be in range 0..8")
+    return sub_idx * 9 + cell_idx
+
+
+def index_to_action(index: int) -> Move:
+    if not 0 <= index < 81:
+        raise ValueError("action index must be in range 0..80")
+    return divmod(index, 9)
+
+
+def apply_mapping_to_move(move: Move, mapping: Sequence[int]) -> Move:
+    """Return the move transformed by the given symmetry mapping."""
+
+    return mapping[move[0]], mapping[move[1]]
+
+
+def canonicalize_state(
+    current_player: Player,
+    boards: Sequence[Sequence[str]],
+    macro_board: Sequence[str],
+    forced_board: Optional[int],
+) -> Tuple[str, Tuple[int, ...]]:
+    best_serialized: Optional[str] = None
+    best_mapping: Tuple[int, ...] = MACRO_MAPPINGS[0]
+
+    for mapping in MACRO_MAPPINGS:
+        transformed_boards: List[List[str]] = [[" "] * 9 for _ in range(9)]
+        transformed_macro: List[str] = [" "] * 9
+
+        for old_macro_index, board in enumerate(boards):
+            new_macro_index = mapping[old_macro_index]
+            transformed_macro[new_macro_index] = macro_board[old_macro_index]
+
+            new_board = [" "] * 9
+            for old_cell_index, value in enumerate(board):
+                new_cell_index = mapping[old_cell_index]
+                new_board[new_cell_index] = value
+            transformed_boards[new_macro_index] = new_board
+
+        new_forced = None if forced_board is None else mapping[forced_board]
+        boards_repr = "|".join("".join(board) for board in transformed_boards)
+        macro_repr = "".join(transformed_macro)
+        forced_repr = "*" if new_forced is None else str(new_forced)
+        serialized = f"{current_player}:{boards_repr}#{macro_repr}#{forced_repr}"
+
+        if best_serialized is None or serialized < best_serialized:
+            best_serialized = serialized
+            best_mapping = mapping
+
+    assert best_serialized is not None
+    return best_serialized, best_mapping

--- a/ultimate_ttt/mcts.py
+++ b/ultimate_ttt/mcts.py
@@ -1,0 +1,148 @@
+"""Monte Carlo Tree Search with PUCT for Ultimate Tic-Tac-Toe."""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+
+from .features import encode_state
+from .game import UltimateTicTacToe, index_to_action
+from .model import PolicyValueNet
+
+__all__ = ["MCTS", "Node"]
+
+
+@dataclass
+class Node:
+    state: UltimateTicTacToe
+    prior: np.ndarray = field(init=False)
+    visit_counts: np.ndarray = field(init=False)
+    total_value: np.ndarray = field(init=False)
+    children: Dict[int, "Node"] = field(default_factory=dict)
+    expanded: bool = False
+
+    def __post_init__(self) -> None:
+        self.prior = np.zeros(81, dtype=np.float32)
+        self.visit_counts = np.zeros(81, dtype=np.int32)
+        self.total_value = np.zeros(81, dtype=np.float32)
+
+    @property
+    def to_move(self) -> str:
+        return self.state.active_player()
+
+    @property
+    def legal_mask(self) -> np.ndarray:
+        return self.state.legal_action_mask()
+
+    def legal_indices(self) -> np.ndarray:
+        return np.flatnonzero(self.legal_mask)
+
+    def select(self, c_puct: float) -> int:
+        legal = self.legal_indices()
+        if legal.size == 0:
+            raise RuntimeError("select called on terminal node")
+        total = self.visit_counts[legal].sum()
+        sqrt_total = math.sqrt(total + 1e-8)
+
+        best_score = -float("inf")
+        best_action = int(legal[0])
+        for action in legal:
+            action = int(action)
+            visits = self.visit_counts[action]
+            q_value = self.total_value[action] / visits if visits > 0 else 0.0
+            u_value = c_puct * self.prior[action] * sqrt_total / (1 + visits)
+            score = q_value + u_value
+            if score > best_score:
+                best_score = score
+                best_action = action
+        return best_action
+
+    def add_child(self, action: int, child: "Node") -> None:
+        self.children[action] = child
+
+
+class MCTS:
+    def __init__(
+        self,
+        model: PolicyValueNet,
+        num_simulations: int = 400,
+        c_puct: float = 2.0,
+        dirichlet_epsilon: float = 0.25,
+        dirichlet_alpha: float = 0.3,
+        device: Optional[torch.device] = None,
+        rng: Optional[np.random.Generator] = None,
+    ) -> None:
+        self.model = model
+        self.num_simulations = num_simulations
+        self.c_puct = c_puct
+        self.dirichlet_epsilon = dirichlet_epsilon
+        self.dirichlet_alpha = dirichlet_alpha
+        self.device = device
+        self.rng = rng or np.random.default_rng()
+
+    def run(self, root_state: UltimateTicTacToe, add_noise: bool = True) -> Tuple[np.ndarray, Node]:
+        root = Node(root_state.clone())
+        if root_state.terminal:
+            return np.zeros(81, dtype=np.float32), root
+        self._evaluate(root)
+        if add_noise:
+            self._apply_dirichlet_noise(root)
+
+        for _ in range(self.num_simulations):
+            node = root
+            scratch = root_state.clone()
+            path: List[Tuple[Node, int]] = []
+
+            while node.expanded and not scratch.terminal:
+                action = node.select(self.c_puct)
+                path.append((node, action))
+                move = index_to_action(action)
+                scratch.make_move(scratch.active_player(), move)
+                child = node.children.get(action)
+                if child is None:
+                    child = Node(scratch.clone())
+                    node.add_child(action, child)
+                node = child
+
+            if scratch.terminal:
+                value_x = scratch.terminal_outcome_from_x_perspective()
+                self._backup(path, value_x)
+                continue
+
+            _, value_x = self._evaluate(node)
+            self._backup(path, value_x)
+
+        pi = root.visit_counts.astype(np.float32)
+        total = pi.sum()
+        if total > 0:
+            pi /= total
+        return pi, root
+
+    def _evaluate(self, node: Node) -> Tuple[np.ndarray, float]:
+        planes, legal = encode_state(node.state)
+        probs, value_x = self.model.inference(planes, legal, device=self.device)
+        legal_indices = np.flatnonzero(legal)
+        node.prior[:] = 0.0
+        node.prior[legal_indices] = probs[legal_indices]
+        prob_sum = node.prior.sum()
+        if prob_sum > 0:
+            node.prior /= prob_sum
+        node.expanded = True
+        return node.prior, value_x
+
+    def _apply_dirichlet_noise(self, node: Node) -> None:
+        legal = node.legal_indices()
+        if legal.size == 0:
+            return
+        noise = self.rng.dirichlet([self.dirichlet_alpha] * legal.size)
+        node.prior[legal] = (1 - self.dirichlet_epsilon) * node.prior[legal] + self.dirichlet_epsilon * noise
+        node.prior[legal] /= node.prior[legal].sum()
+
+    def _backup(self, path: Sequence[Tuple[Node, int]], value_x: float) -> None:
+        for node, action in reversed(path):
+            perspective = value_x if node.to_move == "X" else -value_x
+            node.visit_counts[action] += 1
+            node.total_value[action] += perspective

--- a/ultimate_ttt/model.py
+++ b/ultimate_ttt/model.py
@@ -1,0 +1,104 @@
+"""Neural network used by the AlphaZero-style agent."""
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+from .features import FEATURE_CHANNELS
+
+__all__ = ["PolicyValueNet", "masked_softmax"]
+
+
+def masked_softmax(logits: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    mask = mask.to(dtype=torch.bool)
+    masked_logits = logits.masked_fill(~mask, -1e9)
+    return torch.softmax(masked_logits, dim=-1)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.conv2 = nn.Conv2d(channels, channels, kernel_size=3, padding=1, bias=False)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = F.relu(out)
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = out + x
+        return F.relu(out)
+
+
+class PolicyValueNet(nn.Module):
+    def __init__(
+        self,
+        channels: int = 64,
+        num_blocks: int = 8,
+        policy_hidden: int = 2,
+        value_hidden: int = 128,
+    ) -> None:
+        super().__init__()
+        self.stem = nn.Sequential(
+            nn.Conv2d(FEATURE_CHANNELS, channels, kernel_size=3, padding=1, bias=False),
+            nn.BatchNorm2d(channels),
+            nn.ReLU(inplace=True),
+        )
+        self.trunk = nn.ModuleList(ResidualBlock(channels) for _ in range(num_blocks))
+
+        self.policy_conv = nn.Conv2d(channels, policy_hidden, kernel_size=1, bias=False)
+        self.policy_bn = nn.BatchNorm2d(policy_hidden)
+        self.policy_fc = nn.Linear(policy_hidden * 9 * 9, 81)
+
+        self.value_conv = nn.Conv2d(channels, 1, kernel_size=1, bias=False)
+        self.value_bn = nn.BatchNorm2d(1)
+        self.value_fc1 = nn.Linear(9 * 9, value_hidden)
+        self.value_fc2 = nn.Linear(value_hidden, 1)
+
+    def forward(
+        self, x: torch.Tensor, legal_mask: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:  # type: ignore[override]
+        out = self.stem(x)
+        for block in self.trunk:
+            out = block(out)
+
+        policy = self.policy_conv(out)
+        policy = self.policy_bn(policy)
+        policy = F.relu(policy)
+        policy = policy.view(policy.size(0), -1)
+        policy = self.policy_fc(policy)
+
+        if legal_mask is not None:
+            policy = policy.masked_fill(~legal_mask.to(dtype=torch.bool), -1e9)
+
+        value = self.value_conv(out)
+        value = self.value_bn(value)
+        value = F.relu(value)
+        value = value.view(value.size(0), -1)
+        value = F.relu(self.value_fc1(value))
+        value = torch.tanh(self.value_fc2(value))
+        return policy, value
+
+    @torch.no_grad()
+    def inference(
+        self,
+        planes: np.ndarray,
+        legal_mask: np.ndarray,
+        device: Optional[torch.device] = None,
+    ) -> Tuple[np.ndarray, float]:
+        self.eval()
+        tensor = torch.from_numpy(planes).unsqueeze(0)
+        legal = torch.from_numpy(legal_mask.astype(np.bool_)).unsqueeze(0)
+        if device is not None:
+            tensor = tensor.to(device)
+            legal = legal.to(device)
+        logits, value = self.forward(tensor, legal_mask=legal)
+        probs = torch.softmax(logits, dim=-1).squeeze(0).cpu().numpy()
+        return probs, float(value.item())

--- a/ultimate_ttt/selfplay.py
+++ b/ultimate_ttt/selfplay.py
@@ -1,0 +1,109 @@
+"""Self-play data generation for the AlphaZero-style agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from .features import encode_state
+from .game import UltimateTicTacToe, index_to_action
+from .mcts import MCTS
+from .symmetry import SYMMETRIES
+
+__all__ = ["SelfPlaySample", "play_game", "augment_samples"]
+
+
+@dataclass
+class SelfPlaySample:
+    planes: np.ndarray
+    policy: np.ndarray
+    legal_mask: np.ndarray
+    value_x: float
+
+
+def _select_action(visit_counts: np.ndarray, legal_mask: np.ndarray, temperature: float, rng: np.random.Generator) -> int:
+    legal_indices = np.flatnonzero(legal_mask)
+    if legal_indices.size == 0:
+        raise RuntimeError("No legal moves available for selection")
+
+    visits = visit_counts[legal_indices].astype(np.float64)
+    if temperature <= 1e-6:
+        return int(legal_indices[int(np.argmax(visits))])
+
+    transformed = visits ** (1.0 / max(temperature, 1e-6))
+    total = transformed.sum()
+    if total <= 0:
+        transformed = np.ones_like(transformed) / transformed.size
+    else:
+        transformed /= total
+    choice = rng.choice(len(legal_indices), p=transformed)
+    return int(legal_indices[choice])
+
+
+def play_game(
+    mcts: MCTS,
+    temperature_moves: int = 16,
+    rng: Optional[np.random.Generator] = None,
+) -> List[SelfPlaySample]:
+    rng = rng or np.random.default_rng()
+    game = UltimateTicTacToe()
+    samples: List[SelfPlaySample] = []
+    move_index = 0
+
+    while not game.terminal:
+        planes, legal_mask = encode_state(game)
+        _, root = mcts.run(game)
+        visit_counts = root.visit_counts.astype(np.float32)
+
+        temperature = 1.0 if move_index < temperature_moves else 1e-6
+        action_index = _select_action(visit_counts, legal_mask, temperature, rng)
+
+        policy_target = np.zeros(81, dtype=np.float32)
+        legal_indices = np.flatnonzero(legal_mask)
+        if temperature <= 1e-6:
+            policy_target[action_index] = 1.0
+        elif legal_indices.size > 0:
+            transformed = visit_counts[legal_indices] ** (1.0 / temperature)
+            total = transformed.sum()
+            if total > 0:
+                transformed /= total
+            else:
+                transformed = np.ones_like(transformed) / transformed.size
+            policy_target[legal_indices] = transformed
+
+        samples.append(
+            SelfPlaySample(
+                planes=planes,
+                policy=policy_target,
+                legal_mask=legal_mask.astype(bool),
+                value_x=0.0,
+            )
+        )
+
+        player = game.active_player()
+        game.make_move(player, index_to_action(action_index))
+        move_index += 1
+
+    outcome = game.terminal_outcome_from_x_perspective()
+    for sample in samples:
+        sample.value_x = outcome
+    return samples
+
+
+def augment_samples(samples: Sequence[SelfPlaySample]) -> List[SelfPlaySample]:
+    augmented: List[SelfPlaySample] = []
+    for sample in samples:
+        for symmetry in SYMMETRIES:
+            planes = symmetry.apply_planes(sample.planes)
+            policy = symmetry.apply_policy(sample.policy)
+            legal_mask = symmetry.apply_policy(sample.legal_mask.astype(np.float32)) > 0.5
+            augmented.append(
+                SelfPlaySample(
+                    planes=planes,
+                    policy=policy,
+                    legal_mask=legal_mask,
+                    value_x=sample.value_x,
+                )
+            )
+    return augmented

--- a/ultimate_ttt/symmetry.py
+++ b/ultimate_ttt/symmetry.py
@@ -1,0 +1,125 @@
+"""Utilities for handling board symmetries in Ultimate Tic-Tac-Toe.
+
+The module provides index mappings for the eight rotational and reflection
+symmetries of the 3x3 macro board while keeping the forced-sub-board
+constraint aligned with the corresponding micro boards.  The mappings operate
+both on macro indices (0..8) and on the flattened 9x9 grid (0..80).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import numpy as np
+
+MacroMapping = Tuple[int, ...]
+GlobalMapping = Tuple[int, ...]
+
+
+def _build_macro_mappings() -> Tuple[MacroMapping, ...]:
+    """Return the eight symmetry mappings for indices in a 3x3 grid."""
+
+    def transform(func: Callable[[int, int], Tuple[int, int]]) -> MacroMapping:
+        mapping = []
+        for index in range(9):
+            row, col = divmod(index, 3)
+            new_row, new_col = func(row, col)
+            mapping.append(new_row * 3 + new_col)
+        return tuple(mapping)
+
+    operations = (
+        lambda r, c: (r, c),
+        lambda r, c: (c, 2 - r),
+        lambda r, c: (2 - r, 2 - c),
+        lambda r, c: (2 - c, r),
+        lambda r, c: (r, 2 - c),
+        lambda r, c: (2 - r, c),
+        lambda r, c: (c, r),
+        lambda r, c: (2 - c, 2 - r),
+    )
+
+    return tuple(transform(op) for op in operations)
+
+
+MACRO_MAPPINGS: Tuple[MacroMapping, ...] = _build_macro_mappings()
+
+
+def _build_global_mappings() -> Tuple[GlobalMapping, ...]:
+    """Create symmetry mappings for the flattened 9x9 grid (0..80)."""
+
+    global_mappings: list[GlobalMapping] = []
+    for macro_map in MACRO_MAPPINGS:
+        mapping: list[int] = []
+        for index in range(81):
+            macro_index, cell_index = divmod(index, 9)
+            new_macro = macro_map[macro_index]
+            new_cell = macro_map[cell_index]
+            mapping.append(new_macro * 9 + new_cell)
+        global_mappings.append(tuple(mapping))
+    return tuple(global_mappings)
+
+
+GLOBAL_MAPPINGS: Tuple[GlobalMapping, ...] = _build_global_mappings()
+
+
+def apply_to_macro(index: int, mapping: MacroMapping) -> int:
+    """Apply a macro-level symmetry mapping to ``index``."""
+
+    if not 0 <= index < 9:
+        raise ValueError("macro index must be in range 0..8")
+    return mapping[index]
+
+
+def apply_to_global(index: int, mapping: GlobalMapping) -> int:
+    """Apply a symmetry mapping to an index in the flattened 9x9 grid."""
+
+    if not 0 <= index < 81:
+        raise ValueError("global index must be in range 0..80")
+    return mapping[index]
+
+
+def apply_to_policy(policy: np.ndarray, mapping: GlobalMapping) -> np.ndarray:
+    """Return a copy of ``policy`` after applying the symmetry mapping."""
+
+    flat = np.asarray(policy, dtype=np.float32).reshape(-1)
+    if flat.size != 81:
+        raise ValueError("policy must have exactly 81 entries")
+    transformed = flat[np.array(mapping, dtype=np.intp)]
+    return transformed
+
+
+def apply_to_planes(planes: np.ndarray, mapping: GlobalMapping) -> np.ndarray:
+    """Apply the symmetry mapping to an array of shape ``(C, 9, 9)``."""
+
+    array = np.asarray(planes)
+    if array.ndim != 3 or array.shape[1:] != (9, 9):
+        raise ValueError("planes must have shape (C, 9, 9)")
+    flat = array.reshape(array.shape[0], 81)
+    transformed = flat[:, np.array(mapping, dtype=np.intp)]
+    return transformed.reshape(array.shape)
+
+
+@dataclass(frozen=True)
+class Symmetry:
+    """Convenience wrapper bundling macro and global mappings."""
+
+    macro: MacroMapping
+    global_: GlobalMapping
+
+    def apply_macro(self, index: int) -> int:
+        return apply_to_macro(index, self.macro)
+
+    def apply_global(self, index: int) -> int:
+        return apply_to_global(index, self.global_)
+
+    def apply_planes(self, planes: np.ndarray) -> np.ndarray:
+        return apply_to_planes(planes, self.global_)
+
+    def apply_policy(self, policy: np.ndarray) -> np.ndarray:
+        return apply_to_policy(policy, self.global_)
+
+
+SYMMETRIES: Tuple[Symmetry, ...] = tuple(
+    Symmetry(macro=mapping, global_=GLOBAL_MAPPINGS[idx])
+    for idx, mapping in enumerate(MACRO_MAPPINGS)
+)

--- a/ultimate_ttt/train_az.py
+++ b/ultimate_ttt/train_az.py
@@ -1,0 +1,157 @@
+"""AlphaZero-style training loop for Ultimate Tic-Tac-Toe."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import numpy as np
+import torch
+import yaml
+from torch import nn
+
+from .arena import Arena
+from .model import PolicyValueNet
+from .mcts import MCTS
+from .selfplay import SelfPlaySample, augment_samples, play_game
+from .utils import save_checkpoint, select_device, set_random_seeds
+
+__all__ = ["main", "train"]
+
+
+class ReplayBuffer:
+    def __init__(self, capacity: int) -> None:
+        self.capacity = capacity
+        self._data: List[SelfPlaySample] = []
+
+    def extend(self, samples: Iterable[SelfPlaySample]) -> None:
+        self._data.extend(samples)
+        if len(self._data) > self.capacity:
+            self._data = self._data[-self.capacity :]
+
+    def sample(self, batch_size: int) -> List[SelfPlaySample]:
+        if len(self._data) < batch_size:
+            raise ValueError("Not enough samples in replay buffer")
+        indices = np.random.choice(len(self._data), size=batch_size, replace=False)
+        return [self._data[int(i)] for i in indices]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+def _loss_fn(
+    model: PolicyValueNet,
+    batch: Sequence[SelfPlaySample],
+    device: torch.device,
+) -> torch.Tensor:
+    planes = torch.from_numpy(np.stack([sample.planes for sample in batch])).to(device)
+    legal_mask = torch.from_numpy(
+        np.stack([sample.legal_mask for sample in batch]).astype(np.bool_)
+    ).to(device)
+    target_policy = torch.from_numpy(np.stack([sample.policy for sample in batch])).to(device)
+    target_value = torch.from_numpy(np.array([sample.value_x for sample in batch], dtype=np.float32)).to(device)
+
+    logits, value = model(planes, legal_mask=legal_mask)
+    log_probs = torch.log_softmax(logits, dim=-1)
+    policy_loss = -(target_policy * log_probs).sum(dim=-1).mean()
+    value_loss = nn.functional.mse_loss(value.squeeze(-1), target_value)
+    return policy_loss + value_loss
+
+
+def train(config: Dict[str, Dict[str, float]]) -> None:
+    training_cfg = config.get("training", {})
+    selfplay_cfg = config.get("selfplay", {})
+    replay_cfg = config.get("replay", {})
+    eval_cfg = config.get("evaluation", {})
+
+    seed = int(training_cfg.get("seed", 0))
+    set_random_seeds(seed)
+    device = select_device(training_cfg.get("use_gpu", True))
+
+    model = PolicyValueNet(
+        channels=int(training_cfg.get("channels", 64)),
+        num_blocks=int(training_cfg.get("res_blocks", 8)),
+    ).to(device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(training_cfg.get("learning_rate", 3e-4)),
+        weight_decay=float(training_cfg.get("weight_decay", 1e-4)),
+    )
+
+    baseline = PolicyValueNet(
+        channels=int(training_cfg.get("channels", 64)),
+        num_blocks=int(training_cfg.get("res_blocks", 8)),
+    ).to(device)
+    baseline.load_state_dict(model.state_dict())
+
+    buffer = ReplayBuffer(int(replay_cfg.get("capacity", 200_000)))
+    cycles = int(training_cfg.get("cycles", 1))
+    games_per_cycle = int(selfplay_cfg.get("games_per_cycle", 50))
+    batch_size = int(training_cfg.get("batch_size", 256))
+    train_steps = int(training_cfg.get("steps_per_cycle", 1000))
+
+    checkpoint_path = Path(training_cfg.get("checkpoint", "ultimate_ttt/models/az_checkpoint.pt"))
+
+    for cycle in range(cycles):
+        for _ in range(games_per_cycle):
+            mcts = MCTS(
+                model=model,
+                num_simulations=int(selfplay_cfg.get("simulations", 400)),
+                c_puct=float(selfplay_cfg.get("c_puct", 2.0)),
+                dirichlet_epsilon=float(selfplay_cfg.get("dirichlet_epsilon", 0.25)),
+                dirichlet_alpha=float(selfplay_cfg.get("dirichlet_alpha", 0.3)),
+                device=device,
+            )
+            samples = play_game(
+                mcts,
+                temperature_moves=int(selfplay_cfg.get("temperature_moves", 16)),
+            )
+            if selfplay_cfg.get("augment", True):
+                samples = augment_samples(samples)
+            buffer.extend(samples)
+
+        if len(buffer) < batch_size:
+            continue
+
+        for _ in range(train_steps):
+            batch = buffer.sample(batch_size)
+            optimizer.zero_grad()
+            loss = _loss_fn(
+                model,
+                batch,
+                device,
+            )
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(model.parameters(), float(training_cfg.get("grad_clip", 1.0)))
+            optimizer.step()
+
+        if eval_cfg:
+            interval = int(eval_cfg.get("interval", 1))
+            if (cycle + 1) % interval == 0:
+                arena = Arena(
+                    challenger=model,
+                    baseline=baseline,
+                    mcts_simulations=int(eval_cfg.get("simulations", 200)),
+                    c_puct=float(eval_cfg.get("c_puct", 2.0)),
+                )
+                result = arena.play_matches(int(eval_cfg.get("matches", 200)))
+                if result.win_rate >= float(eval_cfg.get("threshold", 0.55)):
+                    baseline.load_state_dict(model.state_dict())
+
+        save_checkpoint(checkpoint_path, model, optimizer, step=cycle + 1)
+
+    torch.save(model.state_dict(), checkpoint_path.with_suffix(".weights.pt"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train an AlphaZero-style agent for Ultimate Tic-Tac-Toe")
+    parser.add_argument("--config", type=Path, default=Path("ultimate_ttt/config.yaml"))
+    args = parser.parse_args()
+
+    with args.config.open("r", encoding="utf-8") as fh:
+        config = yaml.safe_load(fh)
+    train(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/ultimate_ttt/utils.py
+++ b/ultimate_ttt/utils.py
@@ -1,0 +1,61 @@
+"""Utility helpers for the AlphaZero-style training pipeline."""
+from __future__ import annotations
+
+import random
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+
+__all__ = [
+    "set_random_seeds",
+    "save_checkpoint",
+    "load_checkpoint",
+    "select_device",
+]
+
+
+def set_random_seeds(seed: int) -> None:
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def save_checkpoint(
+    path: Path,
+    model: torch.nn.Module,
+    optimizer: Optional[torch.optim.Optimizer],
+    step: int,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "step": step,
+        "model_state_dict": model.state_dict(),
+    }
+    if optimizer is not None:
+        payload["optimizer_state_dict"] = optimizer.state_dict()
+    if metadata is not None:
+        payload["metadata"] = metadata
+    torch.save(payload, path)
+
+
+def load_checkpoint(
+    path: Path,
+    model: torch.nn.Module,
+    optimizer: Optional[torch.optim.Optimizer] = None,
+) -> Dict[str, Any]:
+    checkpoint = torch.load(path, map_location="cpu")
+    model.load_state_dict(checkpoint["model_state_dict"])
+    if optimizer is not None and "optimizer_state_dict" in checkpoint:
+        optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+    return checkpoint
+
+
+def select_device(prefer_gpu: bool = True) -> torch.device:
+    if prefer_gpu and torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")


### PR DESCRIPTION
## Summary
- add symmetry utilities and expose move/index helpers plus outcome APIs in the game engine
- implement feature extraction, policy-value network, PUCT MCTS, self-play generator, and evaluation arena modules
- create an AlphaZero-style training loop with configuration, replay buffer, and checkpoint utilities

## Testing
- python -m compileall ultimate_ttt

------
https://chatgpt.com/codex/tasks/task_e_68d6d9076d008323b828fc2d20e4f35c