### PR TITLE
Add regression tests for RL canonical move mapping

### DIFF
--- a/tests/test_rl_agent.py
+++ b/tests/test_rl_agent.py
@@ -1,0 +1,80 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from ultimate_ttt.ai import UltimateTTTRLAI, _move_to_key
+from ultimate_ttt.game import UltimateTicTacToe, apply_mapping_to_move
+from ultimate_ttt.train import train_agent
+
+
+def build_asymmetric_game() -> UltimateTicTacToe:
+    game = UltimateTicTacToe()
+    game.boards[0][0] = "X"
+    game.boards[0][8] = "O"
+    game.boards[1][4] = "X"
+    game.macro_board[1] = "X"
+    game.last_move = (1, 4)
+    return game
+
+
+def test_update_maps_moves_into_canonical_orientation():
+    agent = UltimateTTTRLAI()
+    game = build_asymmetric_game()
+    state = agent._state_key(game, "X")
+    move = game.available_moves()[0]
+
+    agent.update(state, move, reward=1.0, next_state=None, next_moves=[])
+
+    state_key, mapping = state
+    canonical_move = apply_mapping_to_move(move, mapping)
+    move_key = _move_to_key(canonical_move)
+
+    assert move_key in agent.q_values[state_key]
+    assert agent.q_values[state_key][move_key] != agent.default_q
+
+
+def test_choose_action_returns_original_orientation_after_update():
+    agent = UltimateTTTRLAI()
+    game = build_asymmetric_game()
+    state = agent._state_key(game, "X")
+    move = game.available_moves()[0]
+
+    agent.update(state, move, reward=1.0, next_state=None, next_moves=[])
+
+    moves = game.available_moves()
+    chosen_move = agent.choose_action(state, moves, epsilon=0.0)
+
+    assert chosen_move == move
+
+
+def test_train_agent_updates_q_table(tmp_path):
+    model_path = tmp_path / "ultimate_ttt_q.json"
+    agent = train_agent(
+        episodes=5,
+        model_path=model_path,
+        epsilon_start=1.0,
+        epsilon_end=1.0,
+        seed=123,
+    )
+
+    assert model_path.exists()
+    with open(model_path, "r", encoding="utf-8") as fh:
+        saved = json.load(fh)
+
+    q_values = saved.get("q_values") if isinstance(saved, dict) else None
+    assert q_values
+
+    has_non_default = False
+    for table in q_values.values():
+        for value in table.values():
+            if value != agent.default_q:
+                has_non_default = True
+                break
+        if has_non_default:
+            break
+
+    assert has_non_default

--- a/ultimate_ttt/game.py
+++ b/ultimate_ttt/game.py
@@ -260,3 +260,19 @@ def canonicalize_state(
 
     assert best_serialized is not None
     return best_serialized, best_mapping
+
+
+def apply_mapping_to_move(move: Move, mapping: Sequence[int]) -> Move:
+    """Transform a move using the provided mapping permutation."""
+
+    sub_index, cell_index = move
+    return mapping[sub_index], mapping[cell_index]
+
+
+def invert_mapping(mapping: Sequence[int]) -> Tuple[int, ...]:
+    """Return the inverse permutation for ``mapping``."""
+
+    inverse = [0] * len(mapping)
+    for original_index, mapped_index in enumerate(mapping):
+        inverse[mapped_index] = original_index
+    return tuple(inverse)

--- a/ultimate_ttt/train.py
+++ b/ultimate_ttt/train.py
@@ -16,30 +16,30 @@ def play_episode(agent: UltimateTTTRLAI, epsilon: float) -> Tuple[str, int]:
     move_count = 0
 
     while not game.terminal:
-        state_key = agent._state_key(game, current_player)
+        state = agent._state_key(game, current_player)
         moves = game.available_moves()
-        move = agent.choose_action(state_key, moves, epsilon)
+        move = agent.choose_action(state, moves, epsilon)
         game.make_move(current_player, move)
         move_count += 1
 
         if game.terminal:
             if game.winner == current_player:
                 reward = 1.0
-                agent.update(state_key, move, reward, None, [])
+                agent.update(state, move, reward, None, [])
                 return current_player, move_count
             if game.is_draw:
-                agent.update(state_key, move, 0.2, None, [])
+                agent.update(state, move, 0.2, None, [])
                 return "draw", move_count
-            agent.update(state_key, move, -1.0, None, [])
+            agent.update(state, move, -1.0, None, [])
             return (
                 ("O" if current_player == "X" else "X"),
                 move_count,
             )
 
         next_player = "O" if current_player == "X" else "X"
-        next_state_key = agent._state_key(game, next_player)
+        next_state = agent._state_key(game, next_player)
         next_moves = game.available_moves()
-        agent.update(state_key, move, 0.0, next_state_key, next_moves)
+        agent.update(state, move, 0.0, next_state, next_moves)
         current_player = next_player
 
     return "draw", move_count


### PR DESCRIPTION
## Summary
- add tests that exercise the RL agent's canonical state mapping during updates and action selection
- cover training persistence with an integration-style test that ensures saved Q-values contain non-default parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68daa6735eb88323a40c3ce12469d5b5